### PR TITLE
Use of better syntax for void closures

### DIFF
--- a/FTPopOverMenu_Swift/FTPopOverMenu.swift
+++ b/FTPopOverMenu_Swift/FTPopOverMenu.swift
@@ -10,24 +10,24 @@ import UIKit
 
 extension FTPopOverMenu {
     
-    public static func showForSender(sender : UIView, with menuArray: [String], done: @escaping (NSInteger)->(), cancel:@escaping ()->()) {
+    public static func showForSender(sender : UIView, with menuArray: [String], done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void) {
         self.sharedMenu.showForSender(sender: sender, or: nil, with: menuArray, menuImageArray: [], done: done, cancel: cancel)
     }
-    public static func showForSender(sender : UIView, with menuArray: [String], menuImageArray: [String], done: @escaping (NSInteger)->(), cancel:@escaping ()->()) {
+    public static func showForSender(sender : UIView, with menuArray: [String], menuImageArray: [String], done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void) {
         self.sharedMenu.showForSender(sender: sender, or: nil, with: menuArray, menuImageArray: menuImageArray, done: done, cancel: cancel)
     }
     
-    public static func showForEvent(event : UIEvent, with menuArray: [String], done: @escaping (NSInteger)->(), cancel:@escaping ()->()) {
+    public static func showForEvent(event : UIEvent, with menuArray: [String], done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void) {
         self.sharedMenu.showForSender(sender: event.allTouches?.first?.view!, or: nil, with: menuArray, menuImageArray: [], done: done, cancel: cancel)
     }
-    public static func showForEvent(event : UIEvent, with menuArray: [String], menuImageArray: [String], done: @escaping (NSInteger)->(), cancel:@escaping ()->()) {
+    public static func showForEvent(event : UIEvent, with menuArray: [String], menuImageArray: [String], done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void) {
         self.sharedMenu.showForSender(sender: event.allTouches?.first?.view!, or: nil, with: menuArray, menuImageArray: menuImageArray, done: done, cancel: cancel)
     }
     
-    public static func showFromSenderFrame(senderFrame : CGRect, with menuArray: [String], done: @escaping (NSInteger)->(), cancel:@escaping ()->()) {
+    public static func showFromSenderFrame(senderFrame : CGRect, with menuArray: [String], done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void) {
         self.sharedMenu.showForSender(sender: nil, or: senderFrame, with: menuArray, menuImageArray: [], done: done, cancel: cancel)
     }
-    public static func showFromSenderFrame(senderFrame : CGRect, with menuArray: [String], menuImageArray: [String], done: @escaping (NSInteger)->(), cancel:@escaping ()->()) {
+    public static func showFromSenderFrame(senderFrame : CGRect, with menuArray: [String], menuImageArray: [String], done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void) {
         self.sharedMenu.showForSender(sender: nil, or: senderFrame, with: menuArray, menuImageArray: menuImageArray, done: done, cancel: cancel)
     }
     
@@ -87,8 +87,8 @@ public class FTPopOverMenu : NSObject {
     var senderFrame : CGRect?
     var menuNameArray : [String]!
     var menuImageArray : [String]!
-    var done : ((_ selectedIndex : NSInteger)->())!
-    var cancel : (()->())!
+    var done : ((_ selectedIndex : NSInteger) -> Void)!
+    var cancel : (() -> Void)!
 
     fileprivate static var sharedMenu : FTPopOverMenu {
         struct Static {
@@ -131,7 +131,7 @@ public class FTPopOverMenu : NSObject {
         return gesture
     }()
 
-    fileprivate func showForSender(sender: UIView?, or senderFrame: CGRect?, with menuNameArray: [String]!, menuImageArray: [String]?, done: @escaping (NSInteger)->(), cancel:@escaping ()->()){
+    fileprivate func showForSender(sender: UIView?, or senderFrame: CGRect?, with menuNameArray: [String]!, menuImageArray: [String]?, done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void){
         
         if sender == nil && senderFrame == nil {
             return
@@ -372,7 +372,7 @@ private class FTPopOverMenuView: UIControl {
     fileprivate var menuNameArray : [String]!
     fileprivate var menuImageArray : [String]?
     fileprivate var arrowDirection : FTPopOverMenuArrowDirection = .Up
-    fileprivate var done : ((NSInteger)->())!
+    fileprivate var done : ((NSInteger) -> Void)!
     
     fileprivate lazy var configuration : FTConfiguration = {
         return FTConfiguration.shared
@@ -389,7 +389,7 @@ private class FTPopOverMenuView: UIControl {
         return tableView
     }()
     
-    fileprivate func showWithAnglePoint(point: CGPoint, frame: CGRect, menuNameArray: [String]!, menuImageArray: [String]!, arrowDirection: FTPopOverMenuArrowDirection, done: @escaping ((NSInteger)->())) {
+    fileprivate func showWithAnglePoint(point: CGPoint, frame: CGRect, menuNameArray: [String]!, menuImageArray: [String]!, arrowDirection: FTPopOverMenuArrowDirection, done: @escaping ((NSInteger) -> Void)) {
         
         self.frame = frame
         


### PR DESCRIPTION
With this commit void closures have better syntax standard which is also suggested by [swiftlint](https://github.com/realm/SwiftLint)