### PR TITLE
Don't try to load an image named empty string

### DIFF
--- a/FTPopOverMenu_Swift/FTPopOverMenu.swift
+++ b/FTPopOverMenu_Swift/FTPopOverMenu.swift
@@ -475,7 +475,7 @@ extension FTPopOverMenuView : UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell : FTPopOverMenuCell = FTPopOverMenuCell(style: .default, reuseIdentifier: FT.PopOverMenuTableViewCellIndentifier)
-        var imageName = ""
+        var imageName: String? = nil
         if menuImageArray != nil {
             if (menuImageArray?.count)! >= indexPath.row + 1 {
                 imageName = (menuImageArray?[indexPath.row])!

--- a/FTPopOverMenu_Swift/FTPopOverMenuCell.swift
+++ b/FTPopOverMenu_Swift/FTPopOverMenuCell.swift
@@ -31,8 +31,17 @@ class FTPopOverMenuCell: UITableViewCell {
 
     func setupCellWith(menuName: String, menuImage: String?) {
         self.backgroundColor = UIColor.clear
-        if menuImage != nil {
-            if var iconImage : UIImage = UIImage(named: menuImage!) {
+        
+        // Configure cell text
+        nameLabel.font = configuration.textFont
+        nameLabel.textColor = configuration.textColor
+        nameLabel.textAlignment = configuration.textAlignment
+        nameLabel.text = menuName
+        nameLabel.frame = CGRect(x: FT.DefaultCellMargin, y: 0, width: configuration.menuWidth - FT.DefaultCellMargin*2, height: configuration.menuRowHeight)
+        
+        // Configure cell icon if available
+        if let menuImage = menuImage {
+            if var iconImage = UIImage(named: menuImage) {
                 if  configuration.ignoreImageOriginalColor {
                     iconImage = iconImage.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
                 }
@@ -40,13 +49,7 @@ class FTPopOverMenuCell: UITableViewCell {
                 iconImageView.frame =  CGRect(x: FT.DefaultCellMargin, y: (configuration.menuRowHeight - configuration.menuIconSize)/2, width: configuration.menuIconSize, height: configuration.menuIconSize)
                 iconImageView.image = iconImage
                 nameLabel.frame = CGRect(x: FT.DefaultCellMargin*2 + configuration.menuIconSize, y: (configuration.menuRowHeight - configuration.menuIconSize)/2, width: (configuration.menuWidth - configuration.menuIconSize - FT.DefaultCellMargin*3), height: configuration.menuIconSize)
-            }else{
-                nameLabel.frame = CGRect(x: FT.DefaultCellMargin, y: 0, width: configuration.menuWidth - FT.DefaultCellMargin*2, height: configuration.menuRowHeight)
             }
         }
-        nameLabel.font = configuration.textFont
-        nameLabel.textColor = configuration.textColor
-        nameLabel.textAlignment = configuration.textAlignment
-        nameLabel.text = menuName
     }
 }


### PR DESCRIPTION
I you don't set any image, the cellForRow code at ```FTPopOverMenu.swift``` (478) will set the image name as "" (empty string) than at ```FTPopOverMenuCell.swift``` class, the menuImage variable will not be nil and will try to load an nonexistent image

Console log
```
2017-10-05 17:48:53.011787-0300 MyAPP [737:133453] [framework] CUICatalog: 
Invalid asset name supplied: ''
```

