### PR TITLE
seperate the global setting, and cell setting.

### DIFF
--- a/FTPopOverMenuDemo/FTPopOverMenuDemo/MoreTableViewController.swift
+++ b/FTPopOverMenuDemo/FTPopOverMenuDemo/MoreTableViewController.swift
@@ -24,7 +24,7 @@ class MoreTableViewController: UITableViewController, MoreTableViewCellDelegate{
         
         FTPopOverMenu.showForEvent(event: event,
                                    with: menuOptionNameArray,
-                                   menuImageArray: ["Pokemon_Go_01","Pokemon_Go_02","Pokemon_Go_03","Pokemon_Go_04","Pokemon_Go_01"] as [AnyObject],
+                                   menuImageArray: ["Pokemon_Go_01","Pokemon_Go_02","Pokemon_Go_03","Pokemon_Go_04","Pokemon_Go_01"],
                                    done: { (selectedIndex) -> () in
                                     
         }) {

--- a/FTPopOverMenuDemo/FTPopOverMenuDemo/ViewController.swift
+++ b/FTPopOverMenuDemo/FTPopOverMenuDemo/ViewController.swift
@@ -9,43 +9,59 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
     }
     
-    var menuOptionNameArray : [String] = ["Share","Delete","Upload","Download"]
-
-    var menuOptionImageNameArray : [String] = ["Pokemon_Go_01","Pokemon_Go_02","Pokemon_Go_03","Pokemon_Go_04"]
+    var menuOptionNameArray = ["Share", "Delete", "Upload", "Download"]
     
-
+    var menuOptionImageNameArray = ["Pokemon_Go_01", "Pokemon_Go_02", "Pokemon_Go_03", "Pokemon_Go_04"]
+    var menuOptionImageImageArray = [#imageLiteral(resourceName: "Pokemon_Go_01"), #imageLiteral(resourceName: "Pokemon_Go_02"), #imageLiteral(resourceName: "Pokemon_Go_03"), #imageLiteral(resourceName: "Pokemon_Go_04")]
+    
+    
     // MARK: -  handle nornal button
     @IBAction func handleButtonTap(_ sender: UIButton) {
-        FTPopOverMenu.showForSender(sender: sender, with: menuOptionNameArray, menuImageArray: menuOptionImageNameArray as [AnyObject], done: { (selectedIndex) -> () in
+        
+        let cellConfi = FTCellConfiguration()
+        cellConfi.textColor = UIColor.black
+        cellConfi.textAlignment = .left
+        cellConfi.textFont = UIFont.systemFont(ofSize: 14)
+        var cellConfis = Array(repeating: cellConfi, count: 4)
+        
+        let cellConfi1 = FTCellConfiguration()
+        cellConfi1.textColor = UIColor.black
+        cellConfis[1] = cellConfi1
+        
+        FTPopOverMenu.showForSender(sender: sender, with: menuOptionNameArray, menuImageArray: menuOptionImageNameArray, cellConfigurationArray: cellConfis, done: { (selectedIndex) in
             print(selectedIndex)
         }) {
-            
+            print("cancel")
         }
     }
     
     // MARK: -  handle NavgationBarButtonItem
     @IBAction func handleNavgationBarButtonTap(_ sender: UIBarButtonItem, event: UIEvent) {
-        FTPopOverMenu.showForEvent(event: event, with: menuOptionNameArray, menuImageArray: menuOptionImageNameArray as [AnyObject], done: { (selectedIndex) -> () in
+        
+        FTPopOverMenu.showForEvent(event: event, with: menuOptionNameArray, menuImageArray: menuOptionImageImageArray, done: { (selectedIndex) in
             print(selectedIndex)
-        }) {
-            
-        }
+        }, cancel: nil)
     }
     
     // MARK: -  handle normal UIBarButtonItem
     @IBAction func handleBarButtonItemTap(_ sender: UIBarButtonItem, event: UIEvent) {
-        FTPopOverMenu.showForEvent(event: event, with: menuOptionNameArray, menuImageArray: menuOptionImageNameArray as [AnyObject], done: { (selectedIndex) -> () in
+        
+        let cellConfi = FTCellConfiguration()
+        cellConfi.textColor = UIColor.blue
+        cellConfi.textAlignment = .left
+        cellConfi.textFont = UIFont.systemFont(ofSize: 14)
+        let cellConfis = Array(repeating: cellConfi, count: 4)
+        
+        FTPopOverMenu.showForEvent(event: event, with: menuOptionNameArray, menuImageArray: nil, cellConfigurationArray: cellConfis, done: { (selectedIndex) in
             print(selectedIndex)
-        }) {
-            
-        }
+        })
         
     }
     
@@ -69,7 +85,7 @@ class ViewController: UIViewController {
 
 extension ViewController {
     
-
+    
     
     func changeToNormalStyle() {
         
@@ -77,13 +93,10 @@ extension ViewController {
         
         
         let config = FTConfiguration.shared
-        config.textColor = UIColor.white
         config.backgoundTintColor = UIColor(red: 80/255, green: 80/255, blue: 80/255, alpha: 1)
         config.borderColor = UIColor(red: 80/255, green: 80/255, blue: 80/255, alpha: 1)
         config.menuWidth = 120
         config.menuSeparatorColor = UIColor.lightGray
-        config.textAlignment = .left
-        config.textFont = UIFont.systemFont(ofSize: 14)
         config.menuRowHeight = 40
         config.cornerRadius = 6
     }
@@ -94,34 +107,27 @@ extension ViewController {
         
         
         let config = FTConfiguration.shared
-        config.textColor = UIColor.black
         config.backgoundTintColor = UIColor.white
         config.borderColor = UIColor.lightGray
         config.menuWidth = 80
         config.menuSeparatorColor = UIColor.lightGray
-        config.textAlignment = .center
-        config.textFont = UIFont.systemFont(ofSize: 14)
         config.menuRowHeight = 40
         config.cornerRadius = 6
-
+        
     }
     
     func changeToQQStyle() {
         
         menuOptionImageNameArray = ["Pokemon_Go_01","Pokemon_Go_02","Pokemon_Go_03","Pokemon_Go_04"]
         
-        
         let config = FTConfiguration.shared
-        config.textColor = UIColor.black
         config.backgoundTintColor = UIColor(white: 0.97, alpha: 1)
         config.borderColor = UIColor.white
         config.menuWidth = 150
         config.menuSeparatorColor = UIColor.lightGray
-        config.textAlignment = .left
-        config.textFont = UIFont.systemFont(ofSize: 16)
         config.menuRowHeight = 50
         config.cornerRadius = 20
-
+        
         
     }
     
@@ -131,13 +137,10 @@ extension ViewController {
         
         
         let config = FTConfiguration.shared
-        config.textColor = UIColor.white
         config.backgoundTintColor = UIColor.red
         config.borderColor = UIColor.red
         config.menuWidth = 120
         config.menuSeparatorColor = UIColor.white
-        config.textAlignment = .left
-        config.textFont = UIFont.systemFont(ofSize: 14)
         config.menuRowHeight = 40
         config.cornerRadius = 10
     }

--- a/FTPopOverMenu_Swift/FT+Extension.swift
+++ b/FTPopOverMenu_Swift/FT+Extension.swift
@@ -1,0 +1,27 @@
+//
+//  FTExtension.swift
+//  FTPopOverMenuDemo
+//
+//  Created by danxiao2 on 2018/6/1.
+//  Copyright © 2018年 chquanquan. All rights reserved.
+//
+
+import UIKit
+
+public protocol Imageable {
+    func getImage() -> UIImage?
+}
+
+extension String: Imageable {
+    public func getImage() -> UIImage? {
+        return UIImage(named: self)
+    }
+}
+
+extension UIImage: Imageable {
+    public func getImage() -> UIImage? {
+        return self
+    }
+}
+
+

--- a/FTPopOverMenu_Swift/FTCellConfiguration.swift
+++ b/FTPopOverMenu_Swift/FTCellConfiguration.swift
@@ -1,0 +1,19 @@
+//
+//  FTCellConfiguration.swift
+//  FTPopOverMenuDemo
+//
+//  Created by danxiao2 on 2018/5/30.
+//  Copyright © 2018年 chquanquan. All rights reserved.
+//
+
+import UIKit
+
+public class FTCellConfiguration : NSObject {
+    
+    public var textColor : UIColor = UIColor.white
+    public var textFont : UIFont = UIFont.systemFont(ofSize: 14)
+    public var textAlignment : NSTextAlignment = NSTextAlignment.left
+    public var ignoreImageOriginalColor = false
+    public var menuIconSize : CGFloat = FT.DefaultMenuIconSize
+    
+}

--- a/FTPopOverMenu_Swift/FTConfiguration.swift
+++ b/FTPopOverMenu_Swift/FTConfiguration.swift
@@ -8,25 +8,20 @@
 
 import UIKit
 
-public class FTConfiguration : NSObject {
+public class FTConfiguration {
 
-    public var menuRowHeight : CGFloat = FT.DefaultMenuRowHeight
-    public var menuWidth : CGFloat = FT.DefaultMenuWidth
-    public var textColor : UIColor = UIColor.white
-    public var textFont : UIFont = UIFont.systemFont(ofSize: 14)
-    public var borderColor : UIColor = FT.DefaultTintColor
-    public var borderWidth : CGFloat = FT.DefaultBorderWidth
-    public var backgoundTintColor : UIColor = FT.DefaultTintColor
-    public var cornerRadius : CGFloat = FT.DefaultCornerRadius
-    public var textAlignment : NSTextAlignment = NSTextAlignment.left
-    public var ignoreImageOriginalColor : Bool = false
-    public var menuIconSize : CGFloat = FT.DefaultMenuIconSize
-    public var menuSeparatorColor : UIColor = UIColor.lightGray
-    public var menuSeparatorInset : UIEdgeInsets = UIEdgeInsetsMake(0, FT.DefaultCellMargin, 0, FT.DefaultCellMargin)
-    public var cellSelectionStyle : UITableViewCellSelectionStyle = .none
-    public var globalShadow : Bool = false
-    public var shadowAlpha : CGFloat = 0.6
-    public var localShadow : Bool = false
+    public var menuRowHeight = FT.DefaultMenuRowHeight
+    public var menuWidth = FT.DefaultMenuWidth
+    public var borderColor = FT.DefaultTintColor
+    public var borderWidth = FT.DefaultBorderWidth
+    public var backgoundTintColor = FT.DefaultTintColor
+    public var cornerRadius = FT.DefaultCornerRadius
+    public var menuSeparatorColor = UIColor.lightGray
+    public var menuSeparatorInset = UIEdgeInsetsMake(0, FT.DefaultCellMargin, 0, FT.DefaultCellMargin)
+    public var cellSelectionStyle = UITableViewCellSelectionStyle.none
+    public var globalShadow = false
+    public var shadowAlpha: CGFloat = 0.6
+    public var localShadow = false
 
     public static var shared : FTConfiguration {
         struct StaticConfig {
@@ -36,26 +31,4 @@ public class FTConfiguration : NSObject {
     }
 
 }
-//public class FTConfiguration : NSObject {
-//
-//    public var menuRowHeight : CGFloat = FTDefaultMenuRowHeight
-//    public var menuWidth : CGFloat = FTDefaultMenuWidth
-//    public var textColor : UIColor = UIColor.white
-//    public var textFont : UIFont = UIFont.systemFont(ofSize: 14)
-//    public var borderColor : UIColor = FTDefaultTintColor
-//    public var borderWidth : CGFloat = FTDefaultBorderWidth
-//    public var backgoundTintColor : UIColor = FTDefaultTintColor
-//    public var cornerRadius : CGFloat = FTDefaultCornerRadius
-//    public var textAlignment : NSTextAlignment = NSTextAlignment.left
-//    public var ignoreImageOriginalColor : Bool = false
-//    public var menuSeparatorColor : UIColor = UIColor.lightGray
-//    public var menuSeparatorInset : UIEdgeInsets = UIEdgeInsetsMake(0, FTDefaultCellMargin, 0, FTDefaultCellMargin)
-//    public var cellSelectionStyle : UITableViewCellSelectionStyle = .none
-//
-//    public static var shared : FTConfiguration {
-//        struct StaticConfig {
-//            static let instance : FTConfiguration = FTConfiguration()
-//        }
-//        return StaticConfig.instance
-//    }
-//}
+

--- a/FTPopOverMenu_Swift/FTPopOverMenu.swift
+++ b/FTPopOverMenu_Swift/FTPopOverMenu.swift
@@ -10,25 +10,16 @@ import UIKit
 
 extension FTPopOverMenu {
     
-    public static func showForSender(sender : UIView, with menuArray: [String], done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void) {
-        self.sharedMenu.showForSender(sender: sender, or: nil, with: menuArray, menuImageArray: [], done: done, cancel: cancel)
+    public static func showForSender(sender : UIView, with menuArray: [String], menuImageArray: [Imageable]? = nil, cellConfigurationArray: [FTCellConfiguration]? = nil, done: @escaping (NSInteger) -> Void, cancel: (() -> Void)? = nil) {
+        self.sharedMenu.showForSender(sender: sender, or: nil, with: menuArray, menuImageArray: menuImageArray, cellConfigurationArray: cellConfigurationArray, done: done, cancel: cancel)
     }
-    public static func showForSender(sender : UIView, with menuArray: [String], menuImageArray: [AnyObject], done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void) {
-        self.sharedMenu.showForSender(sender: sender, or: nil, with: menuArray, menuImageArray: menuImageArray, done: done, cancel: cancel)
-    }
-    
-    public static func showForEvent(event : UIEvent, with menuArray: [String], done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void) {
-        self.sharedMenu.showForSender(sender: event.allTouches?.first?.view!, or: nil, with: menuArray, menuImageArray: [], done: done, cancel: cancel)
-    }
-    public static func showForEvent(event : UIEvent, with menuArray: [String], menuImageArray: [AnyObject], done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void) {
-        self.sharedMenu.showForSender(sender: event.allTouches?.first?.view!, or: nil, with: menuArray, menuImageArray: menuImageArray, done: done, cancel: cancel)
+
+    public static func showForEvent(event : UIEvent, with menuArray: [String], menuImageArray: [Imageable]? = nil, cellConfigurationArray: [FTCellConfiguration]? = nil, done: @escaping (NSInteger) -> Void, cancel: (() -> Void)? = nil) {
+        self.sharedMenu.showForSender(sender: event.allTouches?.first?.view!, or: nil, with: menuArray, menuImageArray: menuImageArray, cellConfigurationArray: cellConfigurationArray, done: done, cancel: cancel)
     }
     
-    public static func showFromSenderFrame(senderFrame : CGRect, with menuArray: [String], done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void) {
-        self.sharedMenu.showForSender(sender: nil, or: senderFrame, with: menuArray, menuImageArray: [], done: done, cancel: cancel)
-    }
-    public static func showFromSenderFrame(senderFrame : CGRect, with menuArray: [String], menuImageArray: [AnyObject], done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void) {
-        self.sharedMenu.showForSender(sender: nil, or: senderFrame, with: menuArray, menuImageArray: menuImageArray, done: done, cancel: cancel)
+    public static func showFromSenderFrame(senderFrame : CGRect, with menuArray: [String], menuImageArray: [Imageable]? = nil, cellConfigurationArray: [FTCellConfiguration]? = nil, done: @escaping (NSInteger) -> Void, cancel: (() -> Void)? = nil) {
+        self.sharedMenu.showForSender(sender: nil, or: senderFrame, with: menuArray, menuImageArray: menuImageArray, cellConfigurationArray: cellConfigurationArray, done: done, cancel: cancel)
     }
     
     public static func dismiss() {
@@ -42,21 +33,22 @@ fileprivate enum FTPopOverMenuArrowDirection {
 }
 
 public class FTPopOverMenu : NSObject {
-
+    
     var sender : UIView?
     var senderFrame : CGRect?
     var menuNameArray : [String]!
-    var menuImageArray : [AnyObject]!
+    var menuImageArray : [Imageable]!
+    var cellConfigurationArray : [FTCellConfiguration]?
     var done : ((_ selectedIndex : NSInteger) -> Void)!
     var cancel : (() -> Void)!
-
+    
     fileprivate static var sharedMenu : FTPopOverMenu {
         struct Static {
             static let instance : FTPopOverMenu = FTPopOverMenu()
         }
         return Static.instance
     }
-
+    
     fileprivate lazy var configuration : FTConfiguration = {
         return FTConfiguration.shared
     }()
@@ -86,14 +78,14 @@ public class FTPopOverMenu : NSObject {
             }
         }
     }
-
+    
     fileprivate lazy var tapGesture : UITapGestureRecognizer = {
         let gesture = UITapGestureRecognizer(target: self, action: #selector(onBackgroudViewTapped(gesture:)))
         gesture.delegate = self
         return gesture
     }()
-
-    fileprivate func showForSender(sender: UIView?, or senderFrame: CGRect?, with menuNameArray: [String]!, menuImageArray: [AnyObject]?, done: @escaping (NSInteger) -> Void, cancel:@escaping () -> Void){
+    
+    fileprivate func showForSender(sender: UIView?, or senderFrame: CGRect?, with menuNameArray: [String]!, menuImageArray: [Imageable]?, cellConfigurationArray: [FTCellConfiguration]? = nil, done: @escaping (NSInteger) -> Void, cancel: (() -> Void)? = nil){
         
         if sender == nil && senderFrame == nil {
             return
@@ -101,11 +93,12 @@ public class FTPopOverMenu : NSObject {
         if menuNameArray.count == 0 {
             return
         }
-
+        
         self.sender = sender
         self.senderFrame = senderFrame
         self.menuNameArray = menuNameArray
         self.menuImageArray = menuImageArray
+        self.cellConfigurationArray = cellConfigurationArray
         self.done = done
         self.cancel = cancel
         
@@ -113,10 +106,10 @@ public class FTPopOverMenu : NSObject {
         
         self.adjustPostionForPopOverMenu()
     }
-
+    
     fileprivate func adjustPostionForPopOverMenu() {
         self.backgroundView.frame = CGRect(x: 0, y: 0, width: UIScreen.ft_width(), height: UIScreen.ft_height())
-
+        
         self.setupPopOverMenu()
         
         self.showIfNeeded()
@@ -127,7 +120,7 @@ public class FTPopOverMenu : NSObject {
         
         self.configurePopMenuFrame()
         
-        popOverMenu.showWithAnglePoint(point: menuArrowPoint, frame: popMenuFrame, menuNameArray: menuNameArray, menuImageArray: menuImageArray, arrowDirection: arrowDirection, done: { (selectedIndex: NSInteger) in
+        popOverMenu.showWithAnglePoint(point: menuArrowPoint, frame: popMenuFrame, menuNameArray: menuNameArray, menuImageArray: menuImageArray, cellConfigurationArray: cellConfigurationArray,  arrowDirection: arrowDirection, done: { (selectedIndex: NSInteger) in
             self.isOnScreen = false
             self.doneActionWithSelectedIndex(selectedIndex: selectedIndex)
         })
@@ -203,8 +196,8 @@ public class FTPopOverMenu : NSObject {
             }
         }
     }
-
-     fileprivate func configureMenuArrowPoint() {
+    
+    fileprivate func configureMenuArrowPoint() {
         var point : CGPoint = CGPoint(x: senderRect.origin.x + (senderRect.size.width)/2, y: 0)
         let menuCenterX : CGFloat = configuration.menuWidth/2 + FT.DefaultMargin
         if senderRect.origin.y + senderRect.size.height/2 < UIScreen.ft_height()/2 {
@@ -221,7 +214,7 @@ public class FTPopOverMenu : NSObject {
         }
         menuArrowPoint = point
     }
-
+    
     @objc fileprivate func onBackgroudViewTapped(gesture : UIGestureRecognizer) {
         self.dismiss()
     }
@@ -263,7 +256,7 @@ public class FTPopOverMenu : NSObject {
             }
         }
     }
-
+    
 }
 
 extension FTPopOverMenu {
@@ -288,35 +281,36 @@ extension FTPopOverMenu {
 }
 
 extension FTPopOverMenu: UIGestureRecognizerDelegate {
-
+    
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         let touchPoint = touch.location(in: backgroundView)
         let touchClass : String = NSStringFromClass((touch.view?.classForCoder)!) as String
         if touchClass == "UITableViewCellContentView" {
             return false
-        }else if CGRect(x: 0, y: 0, width: configuration.menuWidth, height: configuration.menuRowHeight).contains(touchPoint){
+        } else if CGRect(x: 0, y: 0, width: configuration.menuWidth, height: configuration.menuRowHeight).contains(touchPoint){
             // when showed at the navgation-bar-button-item, there is a chance of not respond around the top arrow, so :
             self.doneActionWithSelectedIndex(selectedIndex: 0)
             return false
         }
         return true
     }
-
+    
 }
 
 private class FTPopOverMenuView: UIControl {
     
     fileprivate var menuNameArray : [String]!
-    fileprivate var menuImageArray : [AnyObject]?
+    fileprivate var menuImageArray : [Imageable]?
     fileprivate var arrowDirection : FTPopOverMenuArrowDirection = .up
     fileprivate var done : ((NSInteger) -> Void)!
+    fileprivate var cellConfigurationArray : [FTCellConfiguration]?
     
     fileprivate lazy var configuration : FTConfiguration = {
         return FTConfiguration.shared
     }()
     
     lazy var menuTableView : UITableView = {
-       let tableView = UITableView.init(frame: CGRect.zero, style: UITableViewStyle.plain)
+        let tableView = UITableView.init(frame: CGRect.zero, style: UITableViewStyle.plain)
         tableView.backgroundColor = UIColor.clear
         tableView.delegate = self
         tableView.dataSource = self
@@ -326,35 +320,36 @@ private class FTPopOverMenuView: UIControl {
         return tableView
     }()
     
-    fileprivate func showWithAnglePoint(point: CGPoint, frame: CGRect, menuNameArray: [String]!, menuImageArray: [AnyObject]!, arrowDirection: FTPopOverMenuArrowDirection, done: @escaping ((NSInteger) -> Void)) {
+    fileprivate func showWithAnglePoint(point: CGPoint, frame: CGRect, menuNameArray: [String]!, menuImageArray: [Imageable]?, cellConfigurationArray: [FTCellConfiguration]? = nil, arrowDirection: FTPopOverMenuArrowDirection, done: @escaping ((NSInteger) -> Void)) {
         
         self.frame = frame
-
+        
         self.menuNameArray = menuNameArray
         self.menuImageArray = menuImageArray
+        self.cellConfigurationArray = cellConfigurationArray
         self.arrowDirection = arrowDirection
         self.done = done
         
-        self.repositionMenuTableView()
+        repositionMenuTableView()
         
-        self.drawBackgroundLayerWithArrowPoint(arrowPoint: point)
+        drawBackgroundLayerWithArrowPoint(arrowPoint: point)
     }
     
     fileprivate func repositionMenuTableView() {
-        var menuRect : CGRect = CGRect(x: 0, y: FT.DefaultMenuArrowHeight, width: self.frame.size.width, height: self.frame.size.height - FT.DefaultMenuArrowHeight)
+        var menuRect : CGRect = CGRect(x: 0, y: FT.DefaultMenuArrowHeight, width: frame.size.width, height: frame.size.height - FT.DefaultMenuArrowHeight)
         if (arrowDirection == .down) {
-            menuRect = CGRect(x: 0, y: 0, width: self.frame.size.width, height: self.frame.size.height - FT.DefaultMenuArrowHeight)
+            menuRect = CGRect(x: 0, y: 0, width: frame.size.width, height: frame.size.height - FT.DefaultMenuArrowHeight)
         }
-        self.menuTableView.frame = menuRect
-        self.menuTableView.reloadData()
+        menuTableView.frame = menuRect
+        menuTableView.reloadData()
         if menuTableView.frame.height < configuration.menuRowHeight * CGFloat(menuNameArray.count) {
-            self.menuTableView.isScrollEnabled = true
-        }else{
-            self.menuTableView.isScrollEnabled = false
+            menuTableView.isScrollEnabled = true
+        } else {
+            menuTableView.isScrollEnabled = false
         }
-        self.addSubview(self.menuTableView)
+        addSubview(self.menuTableView)
     }
-
+    
     fileprivate lazy var backgroundLayer : CAShapeLayer = {
         let layer : CAShapeLayer = CAShapeLayer()
         return layer
@@ -365,8 +360,8 @@ private class FTPopOverMenuView: UIControl {
         if self.backgroundLayer.superlayer != nil {
             self.backgroundLayer.removeFromSuperlayer()
         }
-    
-        backgroundLayer.path = self.getBackgroundPath(arrowPoint: arrowPoint).cgPath
+        
+        backgroundLayer.path = getBackgroundPath(arrowPoint: arrowPoint).cgPath
         backgroundLayer.fillColor = configuration.backgoundTintColor.cgColor
         backgroundLayer.strokeColor = configuration.borderColor.cgColor
         backgroundLayer.lineWidth = configuration.borderWidth
@@ -378,13 +373,17 @@ private class FTPopOverMenuView: UIControl {
             backgroundLayer.masksToBounds = false
             backgroundLayer.shouldRasterize = true
             backgroundLayer.rasterizationScale = UIScreen.main.scale
-
+            
         }
         self.layer.insertSublayer(backgroundLayer, at: 0)
         //        backgroundLayer.transform = CATransform3DMakeAffineTransform(CGAffineTransform(rotationAngle: CGFloat(M_PI))) //CATransform3DMakeRotation(CGFloat(M_PI), 1, 1, 0)
     }
     
     func getBackgroundPath(arrowPoint : CGPoint) -> UIBezierPath {
+        
+        let viewWidth = bounds.size.width
+        let viewHeight = bounds.size.height
+        
         let radius : CGFloat = configuration.cornerRadius/2
         
         let path : UIBezierPath = UIBezierPath()
@@ -394,20 +393,20 @@ private class FTPopOverMenuView: UIControl {
             path.move(to: CGPoint(x: arrowPoint.x - FT.DefaultMenuArrowWidth, y: FT.DefaultMenuArrowHeight))
             path.addLine(to: CGPoint(x: arrowPoint.x, y: 0))
             path.addLine(to: CGPoint(x: arrowPoint.x + FT.DefaultMenuArrowWidth, y: FT.DefaultMenuArrowHeight))
-            path.addLine(to: CGPoint(x: self.bounds.size.width - radius, y: FT.DefaultMenuArrowHeight))
-            path.addArc(withCenter: CGPoint(x: self.bounds.size.width - radius, y: FT.DefaultMenuArrowHeight + radius),
+            path.addLine(to: CGPoint(x:viewWidth - radius, y: FT.DefaultMenuArrowHeight))
+            path.addArc(withCenter: CGPoint(x: viewWidth - radius, y: FT.DefaultMenuArrowHeight + radius),
                         radius: radius,
                         startAngle: .pi / 2 * 3,
                         endAngle: 0,
                         clockwise: true)
-            path.addLine(to: CGPoint(x: self.bounds.size.width, y: self.bounds.size.height - radius))
-            path.addArc(withCenter: CGPoint(x: self.bounds.size.width - radius, y: self.bounds.size.height - radius),
+            path.addLine(to: CGPoint(x: viewWidth, y: viewHeight - radius))
+            path.addArc(withCenter: CGPoint(x: viewWidth - radius, y: viewHeight - radius),
                         radius: radius,
                         startAngle: 0,
                         endAngle: .pi / 2,
                         clockwise: true)
-            path.addLine(to: CGPoint(x: radius, y: self.bounds.size.height))
-            path.addArc(withCenter: CGPoint(x: radius, y: self.bounds.size.height - radius),
+            path.addLine(to: CGPoint(x: radius, y: viewHeight))
+            path.addArc(withCenter: CGPoint(x: radius, y: viewHeight - radius),
                         radius: radius,
                         startAngle: .pi / 2,
                         endAngle: .pi,
@@ -425,17 +424,17 @@ private class FTPopOverMenuView: UIControl {
             //            path.addLine(to: CGPoint(x: arrowPoint.x + FTDefaultMenuArrowWidth, y: FTDefaultMenuArrowHeight))
             //            path.close()
         }else{
-            path.move(to: CGPoint(x: arrowPoint.x - FT.DefaultMenuArrowWidth, y: self.bounds.size.height - FT.DefaultMenuArrowHeight))
-            path.addLine(to: CGPoint(x: arrowPoint.x, y: self.bounds.size.height))
-            path.addLine(to: CGPoint(x: arrowPoint.x + FT.DefaultMenuArrowWidth, y: self.bounds.size.height - FT.DefaultMenuArrowHeight))
-            path.addLine(to: CGPoint(x: self.bounds.size.width - radius, y: self.bounds.size.height - FT.DefaultMenuArrowHeight))
-            path.addArc(withCenter: CGPoint(x: self.bounds.size.width - radius, y: self.bounds.size.height - FT.DefaultMenuArrowHeight - radius),
+            path.move(to: CGPoint(x: arrowPoint.x - FT.DefaultMenuArrowWidth, y: viewHeight - FT.DefaultMenuArrowHeight))
+            path.addLine(to: CGPoint(x: arrowPoint.x, y: viewHeight))
+            path.addLine(to: CGPoint(x: arrowPoint.x + FT.DefaultMenuArrowWidth, y: viewHeight - FT.DefaultMenuArrowHeight))
+            path.addLine(to: CGPoint(x: viewWidth - radius, y: viewHeight - FT.DefaultMenuArrowHeight))
+            path.addArc(withCenter: CGPoint(x: viewWidth - radius, y: viewHeight - FT.DefaultMenuArrowHeight - radius),
                         radius: radius,
                         startAngle: .pi / 2,
                         endAngle: 0,
                         clockwise: false)
-            path.addLine(to: CGPoint(x: self.bounds.size.width, y: radius))
-            path.addArc(withCenter: CGPoint(x: self.bounds.size.width - radius, y: radius),
+            path.addLine(to: CGPoint(x: viewWidth, y: radius))
+            path.addArc(withCenter: CGPoint(x: viewWidth - radius, y: radius),
                         radius: radius,
                         startAngle: 0,
                         endAngle: .pi / 2 * 3,
@@ -446,8 +445,8 @@ private class FTPopOverMenuView: UIControl {
                         startAngle: .pi / 2 * 3,
                         endAngle: .pi,
                         clockwise: false)
-            path.addLine(to: CGPoint(x: 0, y: self.bounds.size.height - FT.DefaultMenuArrowHeight - radius))
-            path.addArc(withCenter: CGPoint(x: radius, y: self.bounds.size.height - FT.DefaultMenuArrowHeight - radius),
+            path.addLine(to: CGPoint(x: 0, y: viewHeight - FT.DefaultMenuArrowHeight - radius))
+            path.addArc(withCenter: CGPoint(x: radius, y: viewHeight - FT.DefaultMenuArrowHeight - radius),
                         radius: radius,
                         startAngle: .pi,
                         endAngle: .pi / 2,
@@ -461,7 +460,7 @@ private class FTPopOverMenuView: UIControl {
         }
         return path
     }
-
+    
 }
 
 extension FTPopOverMenuView : UITableViewDelegate {
@@ -476,32 +475,40 @@ extension FTPopOverMenuView : UITableViewDelegate {
             self.done(indexPath.row)
         }
     }
-
+    
 }
 
 extension FTPopOverMenuView : UITableViewDataSource {
-
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return self.menuNameArray.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell : FTPopOverMenuCell = FTPopOverMenuCell(style: .default, reuseIdentifier: FT.PopOverMenuTableViewCellIndentifier)
-        var imageObject: AnyObject? = nil
+        var imageObject: Imageable? = nil
         if menuImageArray != nil {
             if (menuImageArray?.count)! >= indexPath.row + 1 {
-                imageObject = (menuImageArray?[indexPath.row])!
+                imageObject = menuImageArray![indexPath.row]
             }
         }
-        cell.setupCellWith(menuName: menuNameArray[indexPath.row], menuImage: imageObject)
+        
+        var cellConfiguration: FTCellConfiguration!
+        if cellConfigurationArray != nil {
+            cellConfiguration = cellConfigurationArray![indexPath.row]
+        } else {
+            cellConfiguration = FTCellConfiguration()
+        }
+        
+        cell.setupCellWith(menuName: menuNameArray[indexPath.row], menuImage: imageObject, cellConfiguration: cellConfiguration)
         if (indexPath.row == menuNameArray.count-1) {
-            cell.separatorInset = UIEdgeInsetsMake(0, self.bounds.size.width, 0, 0)
-        }else{
+            cell.separatorInset = UIEdgeInsetsMake(0, bounds.size.width, 0, 0)
+        } else {
             cell.separatorInset = configuration.menuSeparatorInset
         }
         cell.selectionStyle = configuration.cellSelectionStyle;
         return cell
     }
-
+    
 }
 

--- a/FTPopOverMenu_Swift/FTPopOverMenuCell.swift
+++ b/FTPopOverMenu_Swift/FTPopOverMenuCell.swift
@@ -29,35 +29,25 @@ class FTPopOverMenuCell: UITableViewCell {
         return label
     }()
 
-    func setupCellWith(menuName: String, menuImage: AnyObject?) {
+    func setupCellWith(menuName: String, menuImage: Imageable?, cellConfiguration: FTCellConfiguration) {
         self.backgroundColor = UIColor.clear
         
         // Configure cell text
-        nameLabel.font = configuration.textFont
-        nameLabel.textColor = configuration.textColor
-        nameLabel.textAlignment = configuration.textAlignment
+        nameLabel.font = cellConfiguration.textFont
+        nameLabel.textColor = cellConfiguration.textColor
+        nameLabel.textAlignment = cellConfiguration.textAlignment
         nameLabel.text = menuName
         nameLabel.frame = CGRect(x: FT.DefaultCellMargin, y: 0, width: configuration.menuWidth - FT.DefaultCellMargin*2, height: configuration.menuRowHeight)
         
         // Configure cell icon if available
-        var iconImage: AnyObject? = nil
-        if let menuImage = menuImage {
-            if menuImage is String {
-                iconImage = UIImage(named: menuImage as! String)
-            } else {
-                if menuImage is UIImage {
-                    iconImage = menuImage
-                }
+        if var iconImage = menuImage?.getImage() {
+            if  cellConfiguration.ignoreImageOriginalColor {
+                iconImage = iconImage.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
             }
-            if iconImage != nil {
-                if  configuration.ignoreImageOriginalColor {
-                    iconImage = iconImage?.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
-                }
-                iconImageView.tintColor = configuration.textColor
-                iconImageView.frame =  CGRect(x: FT.DefaultCellMargin, y: (configuration.menuRowHeight - configuration.menuIconSize)/2, width: configuration.menuIconSize, height: configuration.menuIconSize)
-                iconImageView.image = iconImage as? UIImage
-                nameLabel.frame = CGRect(x: FT.DefaultCellMargin*2 + configuration.menuIconSize, y: (configuration.menuRowHeight - configuration.menuIconSize)/2, width: (configuration.menuWidth - configuration.menuIconSize - FT.DefaultCellMargin*3), height: configuration.menuIconSize)
-            }
+            iconImageView.tintColor = cellConfiguration.textColor
+            iconImageView.frame =  CGRect(x: FT.DefaultCellMargin, y: (configuration.menuRowHeight - cellConfiguration.menuIconSize)/2, width: cellConfiguration.menuIconSize, height: cellConfiguration.menuIconSize)
+            iconImageView.image = iconImage
+            nameLabel.frame = CGRect(x: FT.DefaultCellMargin*2 + cellConfiguration.menuIconSize, y: (configuration.menuRowHeight - cellConfiguration.menuIconSize)/2, width: (configuration.menuWidth - cellConfiguration.menuIconSize - FT.DefaultCellMargin*3), height: cellConfiguration.menuIconSize)
         }
     }
 }

--- a/FTPopOverMenu_Swift/UIControl+Point.swift
+++ b/FTPopOverMenu_Swift/UIControl+Point.swift
@@ -13,21 +13,21 @@ extension UIControl {
     // solution found at: http://stackoverflow.com/a/5666430/6310268
 
     internal func setAnchorPoint(anchorPoint: CGPoint) {
-        var newPoint = CGPoint(x: self.bounds.size.width * anchorPoint.x, y: self.bounds.size.height * anchorPoint.y)
-        var oldPoint = CGPoint(x: self.bounds.size.width * self.layer.anchorPoint.x, y: self.bounds.size.height * self.layer.anchorPoint.y)
+        var newPoint = CGPoint(x: bounds.size.width * anchorPoint.x, y: bounds.size.height * anchorPoint.y)
+        var oldPoint = CGPoint(x: bounds.size.width * layer.anchorPoint.x, y: bounds.size.height * layer.anchorPoint.y)
 
-        newPoint = newPoint.applying(self.transform)
-        oldPoint = oldPoint.applying(self.transform)
+        newPoint = newPoint.applying(transform)
+        oldPoint = oldPoint.applying(transform)
 
-        var position = self.layer.position
+        var position = layer.position
         position.x -= oldPoint.x
         position.x += newPoint.x
 
         position.y -= oldPoint.y
         position.y += newPoint.y
 
-        self.layer.position = position
-        self.layer.anchorPoint = anchorPoint
+        layer.position = position
+        layer.anchorPoint = anchorPoint
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Swift version of [FTPopOverMenu](https://github.com/liufengting/FTPopOverMenu).
 
 [FTPopOverMenu](https://github.com/liufengting/FTPopOverMenu) is a pop over menu for `iOS` which is maybe the easiest one to use, supports both `portrait` and `landscape`. It can show from any `UIView`, any `UIBarButtonItem` and any `CGRect`. Simplest APIs, enable you to change the style in one line of code.
 
+somtimes I want to customer every cell, so I seperate the global setting, and cell setting. e.g: my PM want some menu item are show but can't tap for some reason.
+
 # ScreenShots
 
 ![screenshot](https://raw.githubusercontent.com/liufengting/FTResourceRepo/master/Resource/FTPopOverMenu/screenshots.gif)


### PR DESCRIPTION
Sometimes, I want to set different styles for different cell, so I separate the global settings from the cell settings. For example, my product manager has a requirement. A menu shows it, but it can't be clicked for some reason (to grey text).